### PR TITLE
accept empty DB_AUTH

### DIFF
--- a/src/utils/system/decryptConfig.spec.ts
+++ b/src/utils/system/decryptConfig.spec.ts
@@ -37,7 +37,7 @@ describe("decryptConfig", () => {
       throw new Error("Function did not throw an error");
     } catch (error) {
       if (!(error instanceof Error)) throw error;
-      expect(error.message).to.equal("Password invalid");
+      expect(error.message).to.equal("DB Password invalid");
     }
   });
   it("should return raw configs if password protection if off", () => {

--- a/src/utils/system/decryptConfig.ts
+++ b/src/utils/system/decryptConfig.ts
@@ -6,7 +6,6 @@ export const setDecrypted = (d: boolean) => (decrypted = d);
 
 export const decryptConfig = (password: string) => {
   if (
-    !constants.DB_AUTH ||
     !constants.PRIVKEY ||
     !constants.OLD_PRIVKEY ||
     !constants.FEE_COLLECTOR_PUBKEY
@@ -26,17 +25,17 @@ export const decryptConfig = (password: string) => {
 
   try {
     if (
-      AES.decrypt(constants.DB_AUTH, password).toString(enc.Utf8).length === 0
+      constants.DB_AUTH && AES.decrypt(constants.DB_AUTH, password).toString(enc.Utf8).length === 0
     ) {
-      throw new Error("Password invalid");
+      throw new Error("DB Password invalid");
     }
   } catch (e) {
-    throw new Error("Password invalid");
+    throw new Error("DB Password invalid");
   }
 
   setDecrypted(true);
   return {
-    DB_AUTH: AES.decrypt(constants.DB_AUTH, password).toString(enc.Utf8),
+    DB_AUTH: constants.DB_AUTH ? AES.decrypt(constants.DB_AUTH, password).toString(enc.Utf8) : undefined,
     PRIVKEY: AES.decrypt(constants.PRIVKEY, password).toString(enc.Utf8),
     OLD_PRIVKEY: AES.decrypt(constants.OLD_PRIVKEY, password).toString(
       enc.Utf8,


### PR DESCRIPTION
The current code does not accept an empty DB password. This invalidates the cases where the Database is not password protected, which is very useful for testing purposes